### PR TITLE
Fix capitalization in namespace to match documentation

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kanboard\Plugin\Instantactions;
+namespace Kanboard\Plugin\InstantActions;
 
 use Kanboard\Core\Plugin\Base;
 


### PR DESCRIPTION
The "A" in InstantActions should be capitalized as specified in the documentation . See README.md