### PR TITLE
Change spellings from Instantactions to InstantActions

### DIFF
--- a/Controller/InstaSettingsController.php
+++ b/Controller/InstaSettingsController.php
@@ -1,5 +1,5 @@
 <?php
-namespace Kanboard\Plugin\Instantactions\Controller;
+namespace Kanboard\Plugin\InstantActions\Controller;
 use Kanboard\Controller\BaseController;
 
 /**
@@ -57,7 +57,7 @@ class InstaSettingsController extends BaseController
 	
 
 
-        $this->response->html($this->helper->layout->project('Instantactions:settings', array(
+        $this->response->html($this->helper->layout->project('InstantActions:settings', array(
 	//$this->response->html($this->helper->layout->project('project_edit/show', array(
 
             'owners' => $this->projectUserRoleModel->getAssignableUsersList($project['id'], true),

--- a/Controller/TaskCancellationController.php
+++ b/Controller/TaskCancellationController.php
@@ -1,6 +1,6 @@
 <?php
 //namespace Kanboard\Controller;
-namespace Kanboard\Plugin\Instantactions\Controller;
+namespace Kanboard\Plugin\InstantActions\Controller;
 use Kanboard\Controller\BaseController;
 use Kanboard\Core\Controller\AccessForbiddenException;
 use Kanboard\Model\TaskModel;
@@ -13,7 +13,7 @@ class TaskCancellationController extends BaseController
     public function cancel()
     {
 	$method = "asd";
-	$template = 'Instantactions:cancel';
+	$template = 'InstantActions:cancel';
 	$success_message = 'Task cancelled successfully.';
 	$failure_message = 'Unable to cancel this task.';
 	

--- a/Plugin.php
+++ b/Plugin.php
@@ -8,13 +8,13 @@ class Plugin extends Base
 {
     public function initialize()
     {
-        $this->template->hook->attach('template:board:task:footer', 'Instantactions:layout/footer');
-        $this->template->hook->attach('template:project:sidebar', 'Instantactions:layout/sidebar');
+        $this->template->hook->attach('template:board:task:footer', 'InstantActions:layout/footer');
+        $this->template->hook->attach('template:project:sidebar', 'InstantActions:layout/sidebar');
     }
 
     public function getPluginName()
     {
-        return 'Instantactions';
+        return 'InstantActions';
     }
 
     public function getPluginDescription()

--- a/Template/cancel.php
+++ b/Template/cancel.php
@@ -10,6 +10,6 @@
     <?= $this->modal->confirmButtons(
         'TaskCancellationController',
         'cancel',
-        array('plugin' => 'Instantactions', 'task_id' => $task['id'], 'project_id' => $task['project_id'], 'confirmation' => 'yes')
+        array('plugin' => 'InstantActions', 'task_id' => $task['id'], 'project_id' => $task['project_id'], 'confirmation' => 'yes')
     ) ?>
 </div>

--- a/Template/layout/footer.php
+++ b/Template/layout/footer.php
@@ -57,7 +57,7 @@
 			'TaskCancellationController', 
 			'cancel', 
 			array(
-				'plugin' => 'Instantactions', 
+				'plugin' => 'InstantActions', 
 				'task_id' => $task['id'], 
 				'project_id' => $task['project_id']
 			)

--- a/Template/layout/sidebar.php
+++ b/Template/layout/sidebar.php
@@ -1,6 +1,6 @@
 <li 		
 		<?= $this->app->checkMenuSelection('InstaSettingsController') ?>>
-		<?= $this->url->link(t('Instant Actions'), 'InstaSettingsController', 'show', array('plugin' => 'Instantactions','project_id' => $project['id'])) ?>
+		<?= $this->url->link(t('Instant Actions'), 'InstaSettingsController', 'show', array('plugin' => 'InstantActions','project_id' => $project['id'])) ?>
 		
 </li>
 

--- a/Template/settings.php
+++ b/Template/settings.php
@@ -9,7 +9,7 @@
 <?php endif ?>
 
 
-<form method="post" action="<?= $this->url->href('InstaSettingsController', 'save', array('plugin' => 'Instantactions', 'project_id' => $project['id'], 'redirect' => 'show')) ?>" autocomplete="off">
+<form method="post" action="<?= $this->url->href('InstaSettingsController', 'save', array('plugin' => 'InstantActions', 'project_id' => $project['id'], 'redirect' => 'show')) ?>" autocomplete="off">
     <?= $this->form->csrf() ?>
     <?= $this->form->hidden('id', $values) ?>
 


### PR DESCRIPTION
Fix #5, Fix #6

I did run into a similar case as issues 5 and 6. Making sure the spelling is consistent with namespace and folder did help in my case.